### PR TITLE
Fix nix build issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,8 @@
 A Haskell program which reads the HYG Star Database and uses the Diagrams module to generate a star chart.
 
 ![chart](https://user-images.githubusercontent.com/33742833/56004301-881e9200-5c98-11e9-9e94-cb030ef79596.png)
+
+This project uses nix to pull in the necessary star-data dependencies and feed them into the compiled Haskell program. To build everything and produce an SVG, run
+```ShellSession
+$ nix-build release.nix
+```

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
 { mkDerivation, base, diagrams, diagrams-lib, diagrams-svg
-, parallel, parsec, parsec3-numbers, stdenv
+, parallel, parsec, parsec3-numbers, stdenv, lib
 }:
 mkDerivation {
   pname = "star-chart";
@@ -12,5 +12,5 @@ mkDerivation {
     parsec3-numbers
   ];
   homepage = "https://github.com/githubuser/star-chart#readme";
-  license = stdenv.lib.licenses.bsd3;
+  license = lib.licenses.bsd3;
 }


### PR DESCRIPTION
This PR fixes a small issue that's cropped up in the nix build process since I last worked on this project. Need to now use `lib` instead of `stdenv.lib`.